### PR TITLE
Add missing debugdrawer-okhttp dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     // networking / communication / data storage
     compile 'com.squareup.okhttp:okhttp-urlconnection:2.3.0'
     compile 'com.squareup.okhttp:okhttp:2.3.0'
+    compile 'io.palaima.debugdrawer:debugdrawer-okhttp:0.7.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.google.code.gson:gson:2.6.2'
     compile 'com.squareup.picasso:picasso:2.5.2'


### PR DESCRIPTION
I couldn't get the app to load due to a missing dependency.

Adding this which I found on the [docs for DebugDrawer](https://github.com/palaima/DebugDrawer) fixed all the things.